### PR TITLE
changing the "build:elements" script to none instead of false fixed the issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "build:elements": "ng build --prod --output-hashing false && node build-script.js",
+    "build:elements": "ng build --prod --output-hashing none && node build-script.js",
     "serve:elements": "http-server ./demo -p 4201"
   },
   "private": true,


### PR DESCRIPTION
Great video! I just had an issue with running the `ng build --prod --output-hashing none && node build-script.js` script in package.json on windows 10. Not sure if it is OS specific but this might help someone debug in the future.